### PR TITLE
Allow specifying custom httpclient

### DIFF
--- a/src/dotnet-gqlgen/client.cshtml
+++ b/src/dotnet-gqlgen/client.cshtml
@@ -41,6 +41,18 @@ namespace @Model.Namespace
             this.client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
+        public @(Model.ClientClassName)(HttpClient client)
+            : this(client.BaseAddress, client)
+        {
+        }
+
+        public @(Model.ClientClassName)(Uri apiUrl, HttpClient client)
+        {
+            this.apiUrl = apiUrl;
+            this.client = client;
+            this.client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
         private async Task<GqlResult<TQuery>> ProcessResult<TQuery>(string gql)
         {
             // gql is a GraphQL doc e.g. { query MyQuery { stuff { id name } } }


### PR DESCRIPTION
Allowing a custom HttpClient make it possible to use `DelegatingHandlers` which enables further pre or pos-processing like authentication, logging, metrics, custom serialization e.t.c