### PR TITLE
Private default constructor. Ensure success status code

### DIFF
--- a/src/dotnet-gqlgen/client.cshtml
+++ b/src/dotnet-gqlgen/client.cshtml
@@ -34,16 +34,13 @@ namespace @Model.Namespace
         private Uri apiUrl;
         private readonly HttpClient client;
 
-        public @(Model.ClientClassName)()
+        private @(Model.ClientClassName)()
         {
             this.typeMappings = new Dictionary<string, string> {
                 @foreach(var kvp in Model.Mappings) {
                     @:{ "@kvp.Key" , "@kvp.Value" },
                 }
             };
-            this.apiUrl = new Uri("");
-            this.client = new HttpClient();
-            this.client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         public @(Model.ClientClassName)(HttpClient client)
@@ -71,6 +68,7 @@ namespace @Model.Namespace
             // you will need to implement any auth
             // req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             var res = await client.SendAsync(req);
+            res.EnsureSuccessStatusCode();
             var strResult = await res.Content.ReadAsStringAsync();
             var data = JsonConvert.DeserializeObject<GqlResult<TQuery>>(strResult);
             return data;


### PR DESCRIPTION
I'd like to suggest some improvements in the generated client class.

The default constructor (the one that doesn't accept args) can't be used directly since both apiUrl and client are private fields so from outside the class you can't set the target url. Secondly in my environment the execution fails on ```Uri("")``` with error ```Invalid URI: The URI is empty.```

The other improvement is about http status code checking. If server returns eg 401 (Unauthorized) the code won't throw any error and the ```errors``` field from the GqlResult is empty. Invoking EnsureSuccessStatusCode ensures that on http level the call was successful.