### PR TITLE
Serialize query request fields to lower case

### DIFF
--- a/src/dotnet-gqlgen/BaseGraphQLClient.cs
+++ b/src/dotnet-gqlgen/BaseGraphQLClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace DotNetGqlClient
 {
@@ -240,12 +241,15 @@ namespace DotNetGqlClient
     public class QueryRequest
     {
         // Name of the query or mutation you want to run in the Query (if it contains many)
+        [JsonProperty("operationName")]
         public string OperationName { get; set; }
         /// <summary>
         /// GraphQL query document
         /// </summary>
         /// <value></value>
+        [JsonProperty("query")]
         public string Query { get; set; }
+        [JsonProperty("variables")]
         public Dictionary<string, object> Variables { get; set; }
     }
 


### PR DESCRIPTION
Query request fields are sent in Pascal case. The [apollo](https://www.apollographql.com/docs/apollo-server/v1/requests/#post-requests) server does not recognize these fields. A search on the internet learned that the fields should be camel case, see https://graphql.org/learn/serving-over-http/#post-request.

Added the JsonPropertyAttribute (and not a setting in the serialization method) so that the camel case notation is only limited to those 3 request fields. This will leave for example the fields within variables untouched.

In the serialization part added ```NullValueHandling.Ignore``` so that fields that are null are omitted in the serialized request body.