### PR TITLE
Support for complex type arguments

### DIFF
--- a/src/tests/DotNetGraphQLQueryGen.Tests/GeneratedTypes.cs
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/GeneratedTypes.cs
@@ -7,7 +7,7 @@ using DotNetGqlClient;
 /// <summary>
 /// Generated interfaces for making GraphQL API calls with a typed interface.
 ///
-/// Generated on 20/4/20 6:13:33 pm from ../tests/DotNetGraphQLQueryGen.Tests/schema.graphql -n Generated -c TestHttpClient -m Date=DateTime
+/// Generated on 4/22/2020 12:54:36 AM from ..\tests\DotNetGraphQLQueryGen.Tests\schema.graphql -n Generated -c TestHttpClient -m Date=DateTime
 /// </summary>
 
 namespace Generated
@@ -17,15 +17,20 @@ namespace Generated
     public interface RootQuery
     {
         /// <summary>
-        /// Pagination. [defaults: page = 1, pagesize = 10]
+        /// Returns list of actors paged
+        /// @param page Page number to return [defaults: page = 1]
+        /// @param pagesize Number of items per page to return [pagesize = 10]
+        /// @param search Optional search string
         ///
         /// This shortcut will return a selection of all fields
         /// </summary>
         [GqlFieldName("actorPager")]
         PersonPagination ActorPager();
         /// <summary>
-        /// Pagination. [defaults: page = 1, pagesize = 10]
-        ///
+        /// Returns list of actors paged
+        /// @param page Page number to return [defaults: page = 1]
+        /// @param pagesize Number of items per page to return [pagesize = 10]
+        /// @param search Optional search string
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("actorPager")]
@@ -39,7 +44,6 @@ namespace Generated
         List<Person> Actors();
         /// <summary>
         /// List of actors
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("actors")]
@@ -53,7 +57,6 @@ namespace Generated
         List<Person> Directors();
         /// <summary>
         /// List of directors
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("directors")]
@@ -67,7 +70,6 @@ namespace Generated
         Movie Movie();
         /// <summary>
         /// Return a Movie by its Id
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("movie")]
@@ -81,7 +83,6 @@ namespace Generated
         List<Movie> Movies();
         /// <summary>
         /// Collection of Movies
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("movies")]
@@ -105,7 +106,6 @@ namespace Generated
         List<Person> People();
         /// <summary>
         /// Collection of Peoples
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("people")]
@@ -119,7 +119,6 @@ namespace Generated
         Person Person();
         /// <summary>
         /// Return a Person by its Id
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("person")]
@@ -133,11 +132,23 @@ namespace Generated
         List<Person> Writers();
         /// <summary>
         /// List of writers
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("writers")]
         List<TReturn> Writers<TReturn>(Expression<Func<Person, TReturn>> selection);
+        /// <summary>
+        /// List of producers with filter support
+        ///
+        /// This shortcut will return a selection of all fields
+        /// </summary>
+        [GqlFieldName("producers")]
+        List<Person> Producers();
+        /// <summary>
+        /// List of producers with filter support
+        /// </summary>
+        /// <param name="selection">Projection of fields to select from the object</param>
+        [GqlFieldName("producers")]
+        List<TReturn> Producers<TReturn>(FilterBy filter, Expression<Func<Person, TReturn>> selection);
     }
     public interface SubscriptionType
     {
@@ -169,7 +180,6 @@ namespace Generated
         List<Person> Actors();
         /// <summary>
         /// Actors in the movie
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("actors")]
@@ -183,7 +193,6 @@ namespace Generated
         List<Person> Writers();
         /// <summary>
         /// Writers in the movie
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("writers")]
@@ -252,7 +261,6 @@ namespace Generated
         List<Movie> ActorIn();
         /// <summary>
         /// Movies they acted in
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("actorIn")]
@@ -266,7 +274,6 @@ namespace Generated
         List<Movie> WriterOf();
         /// <summary>
         /// Movies they wrote
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("writerOf")]
@@ -346,7 +353,6 @@ namespace Generated
         List<Person> People();
         /// <summary>
         /// collection of people
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("people")]
@@ -356,7 +362,6 @@ namespace Generated
     {
         /// <summary>
         /// Add a new Movie object
-        ///
         /// </summary>
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("addMovie")]
@@ -371,6 +376,13 @@ namespace Generated
         /// <param name="selection">Projection of fields to select from the object</param>
         [GqlFieldName("addActor2")]
         TReturn AddActor2<TReturn>(string firstName, string lastName, int? movieId, Expression<Func<Person, TReturn>> selection);
+    }
+    public class FilterBy
+    {
+        [GqlFieldName("field")]
+        public string Field { get; set; }
+        [GqlFieldName("value")]
+        public string Value { get; set; }
     }
     public class Detail
     {

--- a/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
@@ -123,7 +123,27 @@ Id: id
 }}
 }}", query.Query, ignoreLineEndingDifferences: true);
 
-            Assert.Equal(@"{""a0"":[1,2,5]}".Replace("\r\n", "\n"), JsonConvert.SerializeObject(query.Variables));
+            Assert.Equal(@"{""a0"":[1,2,5]}", JsonConvert.SerializeObject(query.Variables), ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
+        public void TestComplexValueArg()
+        {
+            var client = new TestClient();
+            var query = client.MakeQuery(q => new
+            {
+                Producers = q.Producers(new FilterBy { Field = "lastName", Value = "Lucas" }, s => new
+                {
+                    s.Id,
+                    s.LastName
+                }),
+            });
+            Assert.Equal($@"query BaseGraphQLClient {{
+Producers: producers(filter: {{ field: ""lastName"", value: ""Lucas"" }}) {{
+Id: id
+LastName: lastName
+}}
+}}", query.Query, ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/src/tests/DotNetGraphQLQueryGen.Tests/VisitorTests.cs
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/VisitorTests.cs
@@ -19,11 +19,11 @@ namespace DotNetGraphQLQueryGen.Tests
             var results = SchemaCompiler.Compile(File.ReadAllText("../../../schema.graphql"));
             Assert.Equal(2, results.Schema.Count);
             Assert.Equal(8, results.Types.Count);
-            Assert.Single(results.Inputs);
+            Assert.Equal(2, results.Inputs.Count);
             var queryTypeName = results.Schema.First(s => s.Name == "query").TypeName;
 
             var queryType = results.Types[queryTypeName];
-            Assert.Equal(9, queryType.Fields.Count);
+            Assert.Equal(10, queryType.Fields.Count);
             Assert.Equal("actors", queryType.Fields.ElementAt(1).Name);
             Assert.Equal("Person", queryType.Fields.ElementAt(1).TypeName);
             Assert.True(queryType.Fields.ElementAt(1).IsArray);
@@ -69,7 +69,7 @@ namespace DotNetGraphQLQueryGen.Tests
             var results = SchemaCompiler.Compile(File.ReadAllText("../../../schema.graphql"));
             Assert.Equal(2, results.Schema.Count);
             Assert.Equal(8, results.Types.Count);
-            Assert.Single(results.Inputs);
+            Assert.Equal(2, results.Inputs.Count);
             var queryTypeName = results.Schema.First(s => s.Name == "query").TypeName;
             var mutationTypeName = results.Schema.First(s => s.Name == "mutation").TypeName;
 

--- a/src/tests/DotNetGraphQLQueryGen.Tests/schema.graphql
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/schema.graphql
@@ -27,7 +27,13 @@ type RootQuery {
 	person(id: Int!): Person
 	"List of writers"
 	writers: [Person]
+	"List of producers with filter support"
+	producers(filter: FilterBy): [Person]
+}
 
+input FilterBy {
+  field: String!
+  value: String!
 }
 
 type SubscriptionType {


### PR DESCRIPTION
The code didn't support ```ExpressionType.MemberInit```. I needed it for support of complex input argument types.

I have following schema:
```
  enum SortDirection {
    ASC,
    DESC
  }

  input SortBy {
    field: String!,
    direction: SortDirection = ASC
  }

  type Query {
    users(sort: SortBy): [User]
  }
```

When I invoke this function as follows it threw the error ```Unsupported argument type MemberInit```
```
var result = await client.QueryAsync(q => new
  {
      Users = q.Users(new SortBy { Direction = SortDirection.ASC, Field = "id" }, s => new
      {
          s.Id,
          s.Username
      })
  });
```

Updated code so it will now generate following gql queries:
```{"query":"query BaseGraphQLClient { Users: users(sort: { direction: ASC, field: \"id\" }) { Id: id Username: username } }","Variables":{}}```