### PR TITLE
Method overloads for methods with optional arguments

### DIFF
--- a/src/dotnet-gqlgen/types.cshtml
+++ b/src/dotnet-gqlgen/types.cshtml
@@ -80,6 +80,8 @@ namespace @Model.Namespace
         @:@field.DotNetType @(field.DotNetName)();
         }
 
+        @foreach(var outputMethodSig in field.OutputMethodSigs())
+        {
         @:/// <summary>
         @if (!string.IsNullOrEmpty(field.Description))
         {
@@ -88,7 +90,8 @@ namespace @Model.Namespace
         @:/// </summary>
         @:/// <param name="selection">Projection of fields to select from the object</param>
         @:[GqlFieldName("@field.Name")]
-        @field.OutputMethodSig()
+        @outputMethodSig
+        }
     }
 }
     @:}


### PR DESCRIPTION
First a non-related note:
> Me again, hope you're not already fed up with me. I try to commit any (isolated) improvements while using your library. That way it's easier for everyone to track the changes and can also describe the problem per scenario and how it's tackled. If you don't prefer this and prefer batch pulls then I can collect them and once I finished (or so done, whichever comes first), send you those changes. Or if you don't want to receive my changes anymore, also let me know :)

This pull request is about missing a function overload for a query function that receives a single, optional argument. There is a default "get all data" function but then I can't specify what values I want it to return. 

Example (should look familiar by now):
```gql
type Query {
  users(sort: SortBy): [User]
}
```
Generates following C# method:
```C#
List<User> Users();
List<TReturn> Users<TReturn>(SortBy sort, Expression<Func<User, TReturn>> selection);
```
If I don't want to specify the (optional) sort I can't pass any selection so initial step was adding this additional function to the list:
```C#
List<TReturn> Users<TReturn>(Expression<Func<User, TReturn>> selection);
```

But then decided to make it more generic and create an overload for every optional argument. So a function like ```users(sort, filter, location)``` will result in 5 method overloads (hope it's not too much). Note, decided to create overloads for the "trailing" optional args only. Reason is that otherwise the code may generate ambiguous functions (different arg names but same arg types). 
Example:
```gql
users(opt: Int, group: String!, sort: SortBy, filterBy: FilterBy): [User]
```
will generate
```C#
List<User> Users();
List<TReturn> Users<TReturn>(int? opt, string group, Expression<...> selection);
List<TReturn> Users<TReturn>(int? opt, string group, sort, Expression<...> selection);
List<TReturn> Users<TReturn>(int? opt, string group, sort, filter, Expression<...> selection);
```

Was only wondering if the first function is correct cause here the group arg is required. But that one was already there so didn't touch that one.