### PR TITLE
Support scalar as return type

### DIFF
--- a/src/dotnet-gqlgen/BaseGraphQLClient.cs
+++ b/src/dotnet-gqlgen/BaseGraphQLClient.cs
@@ -199,6 +199,7 @@ namespace DotNetGqlClient
                     break;
                 case ExpressionType.New:
                 case ExpressionType.NewArrayInit:
+                case ExpressionType.ListInit:
                     argVal = Expression.Lambda(arg).Compile().DynamicInvoke();
                     argType = argVal.GetType();
                     break;

--- a/src/dotnet-gqlgen/BaseGraphQLClient.cs
+++ b/src/dotnet-gqlgen/BaseGraphQLClient.cs
@@ -13,7 +13,7 @@ namespace DotNetGqlClient
     {
         private uint argNum = 0;
         protected Dictionary<string, string> typeMappings;
-        
+
         private class MemberInitDictionary : Dictionary<string, (object, Type)> { }
 
         protected QueryRequest MakeQuery<TSchema, TQuery>(Expression<Func<TSchema, TQuery>> query, bool mutation = false)
@@ -30,7 +30,10 @@ namespace DotNetGqlClient
             if (lambda.Body.NodeType != ExpressionType.New && lambda.Body.NodeType != ExpressionType.MemberInit)
                 throw new ArgumentException($"LambdaExpression must return a NewExpression or MemberInitExpression");
 
-            GetObjectSelection(gql, lambda.Body, args, variables);
+            foreach (var selections in GetObjectSelection(lambda.Body, args, variables))
+            {
+                gql.AppendLine(selections);
+            }
 
             // prepend operationname as it may have arguments
             gql.Insert(0, $"{(mutation ? "mutation" : "query")} BaseGraphQLClient{(args.Any() ? $"({string.Join(",", args)})" : "")} {{\n");
@@ -43,7 +46,7 @@ namespace DotNetGqlClient
             };
         }
 
-        private void GetObjectSelection(StringBuilder gql, Expression exp, List<string> args, Dictionary<string, object> variables)
+        private IEnumerable<string> GetObjectSelection(Expression exp, List<string> args, Dictionary<string, object> variables)
         {
             if (exp.NodeType == ExpressionType.New)
             {
@@ -52,18 +55,22 @@ namespace DotNetGqlClient
                 {
                     var fieldVal = newExp.Arguments[i];
                     var fieldProp = newExp.Members[i];
-                    gql.AppendLine($"{fieldProp.Name}: {GetFieldSelection(fieldVal, args, variables)}");
+                    yield return $"{fieldProp.Name}: {GetFieldSelection(fieldVal, args, variables)}";
                 }
             }
-            else
+            else if (exp.NodeType == ExpressionType.MemberInit)
             {
                 var mi = (MemberInitExpression)exp;
                 for (int i = 0; i < mi.Bindings.Count; i++)
                 {
                     var valExp = ((MemberAssignment)mi.Bindings[i]).Expression;
                     var fieldVal = mi.Bindings[i].Member;
-                    gql.AppendLine($"{fieldVal.Name}: {GetFieldSelection(valExp, args, variables)}");
+                    yield return $"{fieldVal.Name}: {GetFieldSelection(valExp, args, variables)}";
                 }
+            }
+            else
+            {
+                throw new ArgumentException($"Selection {exp.NodeType} \"{exp}\" must be a NewExpression or MemberInitExpression");
             }
         }
 
@@ -117,46 +124,66 @@ namespace DotNetGqlClient
             else
                 select.Append(call.Method.Name);
 
-            if (call.Arguments.Count > 1)
+
+            IEnumerable<string> selection;
+            if (call.Arguments.Count == 0)
             {
+                selection = (call.Method.ReturnType.IsEnumerableOrArray()
+                    ? GetDefaultSelection(call.Method.ReturnType.GetGenericArguments().First())
+                    : GetDefaultSelection(call.Method.ReturnType)).ToList();
+            }
+            else
+            {
+                var selectorExp = call.Arguments.Last();
+
+                if (selectorExp.NodeType == ExpressionType.Quote)
+                    selectorExp = ((UnaryExpression)selectorExp).Operand;
+
+                if (selectorExp.NodeType == ExpressionType.Lambda)
+                    selectorExp = ((LambdaExpression)selectorExp).Body;
+                else
+                    selectorExp = null; // supposed scalar awaited as return
+
+
                 var argVals = new List<string>();
-                for (int i = 0; i < call.Arguments.Count - 1; i++)
+                var parameters = call.Method.GetParameters();
+                var arguments = call.Arguments;
+
+                var count = selectorExp != null
+                    ? arguments.Count - 1
+                    : arguments.Count;
+
+                for (int i = 0; i < count; i++)
                 {
-                    var arg = call.Arguments.ElementAt(i);
-                    var param = call.Method.GetParameters().ElementAt(i);
+                    var arg = call.Arguments[i];
+                    var param = parameters.ElementAt(i);
 
                     (object argVal, Type argType) = ArgToTypeAndValue(arg);
                     if (argVal == null)
                         continue;
 
                     argVals.Add($"{param.Name}: {ArgValToString(operationArgs, variables, param, argType, argVal)}");
-                    ;
                 };
-                if (argVals.Any())
+
+                if (argVals.Count > 0)
                     select.Append($"({string.Join(", ", argVals)})");
+
+                selection = selectorExp != null
+                    ? GetObjectSelection(selectorExp, operationArgs, variables)
+                    : Enumerable.Empty<string>();
             }
-            select.Append(" {" + Environment.NewLine);
-            if (call.Arguments.Count == 0)
+
+            var selectionArray = selection.ToArray();
+            if (selectionArray.Length > 0)
             {
-                if (call.Method.ReturnType.IsEnumerableOrArray())
+                select.Append(" {" + Environment.NewLine);
+                foreach (var line in selectionArray)
                 {
-                    select.Append(GetDefaultSelection(call.Method.ReturnType.GetGenericArguments().First()));
+                    select.AppendLine(line);
                 }
-                else
-                {
-                    select.Append(GetDefaultSelection(call.Method.ReturnType));
-                }
+                select.Append("}");
             }
-            else
-            {
-                var exp = call.Arguments.Last();
-                if (exp.NodeType == ExpressionType.Quote)
-                    exp = ((UnaryExpression)exp).Operand;
-                if (exp.NodeType == ExpressionType.Lambda)
-                    exp = ((LambdaExpression)exp).Body;
-                GetObjectSelection(select, exp, operationArgs, variables);
-            }
-            select.Append("}");
+
             return select.ToString();
         }
 
@@ -165,13 +192,10 @@ namespace DotNetGqlClient
             Type argType;
             object argVal;
 
-            if (arg.NodeType == ExpressionType.Convert)
-            {
-                arg = ((UnaryExpression)arg).Operand;
-            }
-
             switch (arg.NodeType)
             {
+                case ExpressionType.Convert:
+                    return ArgToTypeAndValue(((UnaryExpression)arg).Operand);
                 case ExpressionType.Constant:
                     var constArg = (ConstantExpression)arg;
                     argType = constArg.Type;
@@ -249,9 +273,8 @@ namespace DotNetGqlClient
             }
         }
 
-        private static string GetDefaultSelection(Type returnType)
+        private static IEnumerable<string> GetDefaultSelection(Type returnType)
         {
-            var select = new StringBuilder();
             foreach (var field in returnType.GetProperties())
             {
                 var name = field.Name;
@@ -259,10 +282,10 @@ namespace DotNetGqlClient
                 if (attribute != null)
                     name = attribute.Name;
 
-                select.AppendLine($"{field.Name}: {name}");
+                yield return $"{field.Name}: {name}";
             }
-            return select.ToString();
         }
+
     }
 
     public class QueryRequest

--- a/src/dotnet-gqlgen/dotnet-gqlgen.csproj
+++ b/src/dotnet-gqlgen/dotnet-gqlgen.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
@@ -127,6 +127,25 @@ Id: id
         }
 
         [Fact]
+        public void TestArrayArgExprInited()
+        {
+            var client = new TestClient();
+            var query = client.MakeQuery(q => new
+            {
+                Movies = q.MoviesByIds(new List<int?> { 1, 2, 5 }, s => new
+                {
+                    s.Id,
+                }),
+            });
+            Assert.Equal($@"query BaseGraphQLClient($a0: [Int]) {{
+Movies: moviesByIds(ids: $a0) {{
+Id: id
+}}
+}}", query.Query, ignoreLineEndingDifferences: true);
+
+            Assert.Equal(@"{""a0"":[1,2,5]}", JsonConvert.SerializeObject(query.Variables), ignoreLineEndingDifferences: true);
+        }
+        [Fact]
         public void TestComplexValueArg()
         {
             var client = new TestClient();

--- a/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
+++ b/src/tests/DotNetGraphQLQueryGen.Tests/TestMakeQuery.cs
@@ -70,6 +70,19 @@ Type: type
         }
 
         [Fact]
+        public void MethodWithScalarReturn()
+        {
+            var client = new ClientForCustomQuery<ICustomRootQuery>();
+            var query = client.MakeQuery(_ => new {
+                displayName = _.GetDisplayName(1)
+            });
+            Assert.Equal($@"query BaseGraphQLClient {{
+displayName: GetDisplayName(id: 1)
+}}", query.Query, ignoreLineEndingDifferences: true);
+        }
+
+
+        [Fact]
         public void TypedClass()
         {
             var client = new TestClient();
@@ -109,7 +122,7 @@ Id: id
         public void TestArrayArg()
         {
             var client = new TestClient();
-            var idList = new List<int?> {1, 2, 5};
+            var idList = new List<int?> { 1, 2, 5 };
             var query = client.MakeQuery(q => new
             {
                 Movies = q.MoviesByIds(idList, s => new
@@ -145,6 +158,7 @@ Id: id
 
             Assert.Equal(@"{""a0"":[1,2,5]}", JsonConvert.SerializeObject(query.Variables), ignoreLineEndingDifferences: true);
         }
+
         [Fact]
         public void TestComplexValueArg()
         {
@@ -205,5 +219,14 @@ LastName: lastName
     public class MyResult
     {
         public List<MovieResult> Movies { get; set; }
+    }
+
+    public class ClientForCustomQuery<TRootQuery>: TestHttpClient
+    {
+        public QueryRequest MakeQuery<TReturn>(Expression<Func<TRootQuery, TReturn>> exp) => base.MakeQuery<TRootQuery, TReturn>(exp);
+    }
+
+    public interface ICustomRootQuery {
+        string GetDisplayName(int id);
     }
 }


### PR DESCRIPTION
Hi i'm glad to see that my changes were applied and hope this will too. To test scalar return i wrote ICustomQueryRoot because dotnet-gqlgen don`t support it and generate like this:

        string GetDisplayName();
        TReturn GetDisplayName<TReturn>(int? id, Expression<Func<string, TReturn>> selection);

but in schema: 	
     getDisplayName(id: Int): String

spec:
https://spec.graphql.org/draft/#example-81f19