### PR TITLE
Added -h arg for header values for introspection endpoint

### DIFF
--- a/src/dotnet-gqlgen/Properties/launchSettings.json
+++ b/src/dotnet-gqlgen/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "dotnet-gqlgen": {
-      "commandName": "Project",
-      "commandLineArgs": "https://api.graph.cool/simple/v1/ciyz901en4j590185wkmexyex -m Date=DateTime"
-    }
-  }
-}


### PR DESCRIPTION
As discussed, added a new argument -h (header) that you can use to pass any header value to the graphql introspection endpoint.

Example: dotnet run -- http://yourendpoint/gql -h "Authorization=Bearer ey...,X-API-Key=12kklj21HJ"